### PR TITLE
chore: harden .gitignore for Node/Vite/Replit artifacts and secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,65 +2,44 @@
 node_modules/
 npm-debug.log*
 yarn-debug.log*
-yarn-error.log*
-.pnpm-debug.log*
-
-# Choose npm lockfile to keep; ignore others (we keep package-lock.json)
-yarn.lock
-pnpm-lock.yaml
-
-# Build outputs
-dist/
-build/
-.vite/
-.cache/
-coverage/
-
-# Test artifacts
-playwright-report/
-test-results/
-
-# Logs / PIDs / temp
+pnpm-debug.log*
 logs/
 *.log
 *.log.*
+pids/
 *.pid
-server.pid
-tmp/
-.temp/
-*.swp
-*.swo
+*.pid.lock
 
-# Env & secrets
+# Env (keep example files tracked)
 .env
 .env.*
 !.env.example
 
-# Editors / OS
+# Build / cache
+dist/
+build/
+coverage/
+.nyc_output/
+.cache/
+.vite/
+.turbo/
+server.pid
+tmp/
+temp/
+*.tmp
+
+# Test artifacts
+cypress/videos/
+cypress/screenshots/
+playwright-report/
+test-results/
+
+# OS/editor
 .DS_Store
 Thumbs.db
+.vscode/
 .idea/
-.vscode/*
-!.vscode/extensions.json
-!.vscode/settings.json
 
 # Replit
 .repl_history
-# Keep .replit tracked if you need reproducible run config
-
-# App-specific runtime
-uploads/
-storage/
-vector_index/
-knowledge_store/
-tmp/
-.temp/
-drizzle/*-journal
-pgdata/
-
-# Local scratch files
-attached_assets/
-snap-*.zip
-
-# Local editor assets (Replit)
-attached_assets/
+.replit.lsp


### PR DESCRIPTION
## Summary
Explain the change in plain English. Mention the user impact.

## Checklist
- [ ] No secrets committed. `.env*` ignored; `.env.example` uses placeholders only.
- [ ] Rebased on latest `main` (`git fetch origin && git rebase origin/main`).
- [ ] Local build green: `npm ci && npm run build`.
- [ ] Scope is tight; commits are clean and descriptive.
- [ ] Tests updated/added if it’s logic, or consciously skipped if UI-only.
- [ ] Docs updated if behaviour/config changed (README, docs/WORKFLOW.md, CONTRIBUTING.md).

## Screenshots / Logs (if UI or errors)
_Paste images or relevant log excerpts._

## Notes for reviewers
Call out risky areas, migrations, feature flags, or follow-ups.
