### PR TITLE
docs: add CONTRIBUTING with branch/CI/secrets/MSW guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,21 +1,33 @@
 # Contributing
 
-This repo treats GitHub as the source of truth. Read the full workflow: [docs/WORKFLOW.md](docs/WORKFLOW.md).
+## Branches & PRs
+- Work on short-lived branches off `main`. Name like `feat/<scope>` `fix/<scope>` `docs/<scope>`.
+- Rebase on `main` before opening a PR. Keep history linear.
+- Open PRs against `main`. One clear change per PR.
+- CI (**node-ci**) must be green and the branch up-to-date. At least 1 approval required.
+- Code owners: @Ivan2san is requested automatically.
 
-## Quick start
-```bash
-# Update local main
-git switch main && git pull --ff-only
+## Local dev
+- Node 20. Use `npm ci` to install.
+- Start dev: `npm run dev` (Replit targets port 5000).
+- Typecheck: `npm run typecheck:ci || npx tsc --noEmit`
+- Build: `npm run build --if-present`
+- Test: `npm test --if-present`
 
-# Branch from main
-git switch -c feature/<slug>
+## MSW (Mock Service Worker)
+- Disabled by default.
+- Enable in dev by setting secret: `VITE_ENABLE_MSW=true`.
+- App only starts MSW in dev when that secret is set.
 
-# Commit in small chunks
-git add -A && git commit -m "<type>: <message>"
+## Secrets & env
+- Never commit secrets. Use Replit Secrets or a local `.env` (ignored by Git).
+- Keep `.env.example` up to date with non-secret keys.
+- GitHub is the source of truth; Replit is a working copy.
 
-# Rebase before PR
-git fetch origin
-git rebase origin/main
+## Git hygiene
+- Always pull fast-forward: `git pull --ff-only`.
+- Push branches; do **not** push to `main`. Merges happen via PRs.
+- If you must rewrite history on a branch, use `--force-with-lease` (never to `main`).
 
-# Push and open PR
-git push -u origin HEAD
+## Ignore files
+- `.gitignore` already excludes `node_modules`, `dist`, logs, and `.env`. Don’t add built artifacts.


### PR DESCRIPTION
## Summary
Explain the change in plain English. Mention the user impact.

## Checklist
- [ ] No secrets committed. `.env*` ignored; `.env.example` uses placeholders only.
- [ ] Rebased on latest `main` (`git fetch origin && git rebase origin/main`).
- [ ] Local build green: `npm ci && npm run build`.
- [ ] Scope is tight; commits are clean and descriptive.
- [ ] Tests updated/added if it’s logic, or consciously skipped if UI-only.
- [ ] Docs updated if behaviour/config changed (README, docs/WORKFLOW.md, CONTRIBUTING.md).

## Screenshots / Logs (if UI or errors)
_Paste images or relevant log excerpts._

## Notes for reviewers
Call out risky areas, migrations, feature flags, or follow-ups.
